### PR TITLE
Turn off delay after the job has  been triggered.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -15,6 +15,13 @@
                 "decription": "The time to fire off your job, in CRON syntax.",
                 "type": "string",
                 "required": true
+            },
+            "turnOffDelay": {
+                "title": "Turn off delay in milliseconds",
+                "decription": "Milliseconds until the accessory is turned off after the job has been triggered. Default: 100",
+                "type": "number",
+                "required": false,
+                "default": 100
             }
         }
     }

--- a/src/accessory.js
+++ b/src/accessory.js
@@ -40,7 +40,7 @@ class Accessory {
 
         let job = new cron(this.config.cron, () => {
             this.service.updateCharacteristic(Characteristic.On, true);
-            setTimeout(() => this.service.updateCharacteristic(Characteristic.On, false), 100);
+            setTimeout(() => this.service.updateCharacteristic(Characteristic.On, false), this.config.turnOffDelay);
         });
 
         job.start();


### PR DESCRIPTION
Hello
Great plugin, however I had some issues with the accessory trying to turn off "too fast", basically making it being stuck in "on-mode" and therefore not working, so I added a simple config option to change the turn off delay :)